### PR TITLE
Prevent double clicks with global loading state and replace full reloads with targeted refreshes

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { PagesComponent } from './pages/pages.component';
 import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { TokenInterceptor } from './interceptors/tokenInterceptor';
 import { AuthInterceptor } from './interceptors/authInterceptor';
+import { LoadingInterceptor } from './interceptors/loading.interceptor';
 import { registerLocaleData } from '@angular/common';
 import { NgChartsModule } from 'ng2-charts';
 import localeEs from '@angular/common/locales/es-CO';
@@ -136,6 +137,7 @@ registerLocaleData(localeEs, 'es-CO');
         { provide: DEFAULT_CURRENCY_CODE, useValue: 'COP' },
         { provide: HTTP_INTERCEPTORS, useClass: TokenInterceptor, multi: true },
         { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+        { provide: HTTP_INTERCEPTORS, useClass: LoadingInterceptor, multi: true },
         provideHttpClient(withInterceptorsFromDi())
     ] })
 export class AppModule { }

--- a/src/app/interceptors/loading.interceptor.ts
+++ b/src/app/interceptors/loading.interceptor.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { LoadingService } from '../shared/loading/loading.service';
+
+@Injectable()
+export class LoadingInterceptor implements HttpInterceptor {
+  constructor(private loadingService: LoadingService) {}
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    this.loadingService.increment();
+
+    return next.handle(req).pipe(finalize(() => this.loadingService.decrement()));
+  }
+}

--- a/src/app/pages/inventario/bodegas/bodegas.component.ts
+++ b/src/app/pages/inventario/bodegas/bodegas.component.ts
@@ -160,6 +160,8 @@ export class BodegasComponent implements OnInit {
 
 
   sincronizarBodegas() {
+    if (this.sincronizando) return;
+
     Swal.fire({
       title: '¿Sincronizar con SIESA?',
       text: 'Se actualizará el estado de existencias de los items',
@@ -192,7 +194,7 @@ export class BodegasComponent implements OnInit {
               timer: 1500,
               showConfirmButton: false
             }).then(() => {
-              window.location.reload();
+              this.refrescarDatosPostSincronizacion();
             });
           },
           error: () => {
@@ -207,6 +209,14 @@ export class BodegasComponent implements OnInit {
         });
       }
     });
+  }
+
+  private refrescarDatosPostSincronizacion(): void {
+    this.cargarBodegas();
+
+    if (this.vistaActual === 'items' && this.codigoBodega && this.nombreBodega) {
+      this.verItemsDeBodega(this.codigoBodega, this.nombreBodega);
+    }
   }
 
   /** -------------------------

--- a/src/app/pages/terminacion-empaque/distribucion-pv/distribucion-pv.component.ts
+++ b/src/app/pages/terminacion-empaque/distribucion-pv/distribucion-pv.component.ts
@@ -890,51 +890,75 @@ private ordenarPVs(op: any): void {
     this.opSeleccionada = op;
 
     try {
-      const items = await this.terminacionEmpaqueService
-        .listarItemsDePVDesdeApiLaravel(+pv, op)
-        .toPromise();
+      await this.cargarItemsParaPV(op, pv, true);
+    } catch (err) {
+      Swal.fire('Error', 'No se pudieron cargar los ítems de la PV', 'error');
+      console.error('Error al cargar ítems de PV', op, pv, err);
+    }
+  }
 
-      this.items = items.map(i => {
-        const cantidadTeorica = parseFloat(String(i.cantidad || 0)) || 0;
-        const cantidadRecibida = parseFloat(String(i.cantidad_recibida || i.cantidad_recibida_total || 0)) || 0;
-        const cantidadAsignada = parseFloat(String(i.cantidad_asignada || 0)) || 0;
+  private async cargarItemsParaPV(op: number, pv: string, mostrarModal: boolean): Promise<void> {
+    const items = await this.terminacionEmpaqueService
+      .listarItemsDePVDesdeApiLaravel(+pv, op)
+      .toPromise();
 
-        let cantidadEmpaque = 0;
-        if (Array.isArray(i.ubicaciones_distintas)) {
-          const ubicacionEmpaque = i.ubicaciones_distintas.find(
-            u => u.ubicacion?.toLowerCase() === 'empaque'
-          );
-          if (ubicacionEmpaque) {
-            cantidadEmpaque = parseFloat(String(ubicacionEmpaque.cantidad || 0)) || 0;
-          }
-        } else if (i.ubicacion?.toLowerCase() === 'empaque') {
-          cantidadEmpaque = parseFloat(String(i.cantidad || 0)) || 0;
+    this.items = items.map(i => {
+      const cantidadTeorica = parseFloat(String(i.cantidad || 0)) || 0;
+      const cantidadRecibida = parseFloat(String(i.cantidad_recibida || i.cantidad_recibida_total || 0)) || 0;
+      const cantidadAsignada = parseFloat(String(i.cantidad_asignada || 0)) || 0;
+
+      let cantidadEmpaque = 0;
+      if (Array.isArray(i.ubicaciones_distintas)) {
+        const ubicacionEmpaque = i.ubicaciones_distintas.find(
+          u => u.ubicacion?.toLowerCase() === 'empaque'
+        );
+        if (ubicacionEmpaque) {
+          cantidadEmpaque = parseFloat(String(ubicacionEmpaque.cantidad || 0)) || 0;
         }
+      } else if (i.ubicacion?.toLowerCase() === 'empaque') {
+        cantidadEmpaque = parseFloat(String(i.cantidad || 0)) || 0;
+      }
 
-        return {
-          ...i,
-          cantidad: cantidadTeorica,
-          cantidad_recibida: cantidadRecibida,
-          cantidad_asignada: cantidadAsignada,
-          cantidad_en_empaque: cantidadEmpaque,
-          cantidad_a_asignar: 0
-        };
-      });
+      return {
+        ...i,
+        cantidad: cantidadTeorica,
+        cantidad_recibida: cantidadRecibida,
+        cantidad_asignada: cantidadAsignada,
+        cantidad_en_empaque: cantidadEmpaque,
+        cantidad_a_asignar: 0
+      };
+    });
 
-      this.itemFilters = { busqueda: '', soloDisponibles: false };
-      this.initializarPaginacionItems();
+    this.itemFilters = { busqueda: '', soloDisponibles: false };
+    this.initializarPaginacionItems();
 
-      this.pvSeleccionada = pv;
-      this.ocCliente = this.items[0]?.oc_cliente || 'N/A';
+    this.pvSeleccionada = pv;
+    this.ocCliente = this.items[0]?.oc_cliente || 'N/A';
 
+    if (mostrarModal) {
       const modalEl = document.getElementById('itemsModal');
       if (modalEl) {
         const modal = new Modal(modalEl);
         modal.show();
       }
-    } catch (err) {
-      Swal.fire('Error', 'No se pudieron cargar los ítems de la PV', 'error');
-      console.error('Error al cargar ítems de PV', op, pv, err);
+    }
+  }
+
+  private async refrescarDespuesAsignacion(): Promise<void> {
+    if (!this.opSeleccionada || !this.pvSeleccionada) return;
+
+    try {
+      await this.cargarItemsParaPV(this.opSeleccionada, this.pvSeleccionada, false);
+
+      const op = this.opsConPvs.find(o => o.codigo === this.opSeleccionada);
+      if (op?.pvsOriginal) {
+        await this.verificarDisponibilidadPorPV(op.codigo, op.pvsOriginal);
+        await this.preCargarAsignacionesPendientes(op.codigo, op.pvsOriginal);
+        this.ordenarPVs(op);
+        this.filtrarPVs(op);
+      }
+    } catch (error) {
+      console.error('Error al refrescar datos después de asignar:', error);
     }
   }
 
@@ -1088,35 +1112,40 @@ private ordenarPVs(op: any): void {
       : this.terminacionEmpaqueService.registrarAsignaciones(itemsParaEnviar, this.pvSeleccionada, this.opSeleccionada, this.usuario_que_registra);
 
     servicio.subscribe({
-      next: (res: any) => {
+      next: async (res: any) => {
         this.items.forEach(item => item.cantidad_a_asignar = 0);
-        
-        if (res.message) {
-          Swal.fire('Éxito', res.message, 'success').then(() => window.location.reload());
-        } else if (res.valid !== undefined) {
-          if (!res.valid) {
-            const errores = (res.items || [])
-              .filter((r: any) => !r.valid)
-              .map((r: any) => `Item ${r.f120_id || r.referencia || ''}: ${r.errors.join(', ')}`)
-              .join('<br/>');
 
-            Swal.fire({
-              title: 'Errores en asignaciones',
-              html: errores || 'Hay errores en algunas asignaciones',
-              icon: 'error',
-              width: 700
-            });
-            this.assignmentPayload = res.items || [];
-          } else {
-            this.assignmentPayload = res.items || [];
-            Swal.fire({
-              title: 'Asignaciones válidas',
-              html: `Se validaron ${this.assignmentPayload.length} ítems.`,
-              icon: 'success'
-            }).then(() => window.location.reload());
+        try {
+          if (res.message) {
+            await Swal.fire('Éxito', res.message, 'success');
+            await this.refrescarDespuesAsignacion();
+          } else if (res.valid !== undefined) {
+            if (!res.valid) {
+              const errores = (res.items || [])
+                .filter((r: any) => !r.valid)
+                .map((r: any) => `Item ${r.f120_id || r.referencia || ''}: ${r.errors.join(', ')}`)
+                .join('<br/>');
+
+              Swal.fire({
+                title: 'Errores en asignaciones',
+                html: errores || 'Hay errores en algunas asignaciones',
+                icon: 'error',
+                width: 700
+              });
+              this.assignmentPayload = res.items || [];
+            } else {
+              this.assignmentPayload = res.items || [];
+              await Swal.fire({
+                title: 'Asignaciones válidas',
+                html: `Se validaron ${this.assignmentPayload.length} ítems.`,
+                icon: 'success'
+              });
+              await this.refrescarDespuesAsignacion();
+            }
           }
+        } finally {
+          this.guardandoAsignacion = false;
         }
-        this.guardandoAsignacion = false;
       },
       error: () => {
         Swal.fire('Error', 'No se pudo registrar las asignaciones.', 'error');

--- a/src/app/shared/loading/loading-button.directive.ts
+++ b/src/app/shared/loading/loading-button.directive.ts
@@ -1,0 +1,87 @@
+import {
+  Directive,
+  ElementRef,
+  HostListener,
+  OnDestroy,
+  OnInit,
+  Renderer2
+} from '@angular/core';
+import { Subscription } from 'rxjs';
+import { LoadingService } from './loading.service';
+
+@Directive({
+  selector: 'button'
+})
+export class LoadingButtonDirective implements OnInit, OnDestroy {
+  private subscription?: Subscription;
+  private isLoading = false;
+  private awaitingRequest = false;
+  private restoreDisabled = false;
+  private pendingTimeoutId?: number;
+
+  constructor(
+    private elementRef: ElementRef<HTMLButtonElement>,
+    private renderer: Renderer2,
+    private loadingService: LoadingService
+  ) {}
+
+  ngOnInit(): void {
+    this.subscription = this.loadingService.pending$.subscribe(count => {
+      if (!this.awaitingRequest) return;
+
+      if (count > 0 && !this.isLoading) {
+        this.setLoadingState(true);
+        return;
+      }
+
+      if (count === 0 && this.isLoading) {
+        this.setLoadingState(false);
+        this.awaitingRequest = false;
+      }
+    });
+  }
+
+  @HostListener('click')
+  onClick(): void {
+    if (this.isLoading) return;
+
+    this.awaitingRequest = true;
+    this.restoreDisabled = !this.elementRef.nativeElement.disabled;
+    this.renderer.setProperty(this.elementRef.nativeElement, 'disabled', true);
+
+    if (this.pendingTimeoutId) {
+      window.clearTimeout(this.pendingTimeoutId);
+    }
+
+    this.pendingTimeoutId = window.setTimeout(() => {
+      if (!this.loadingService.hasPending() && this.awaitingRequest) {
+        this.awaitingRequest = false;
+        this.setLoadingState(false);
+      }
+    }, 300);
+  }
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+    if (this.pendingTimeoutId) {
+      window.clearTimeout(this.pendingTimeoutId);
+    }
+  }
+
+  private setLoadingState(loading: boolean): void {
+    this.isLoading = loading;
+
+    if (loading) {
+      this.renderer.addClass(this.elementRef.nativeElement, 'app-loading-button');
+      this.renderer.setAttribute(this.elementRef.nativeElement, 'aria-busy', 'true');
+      return;
+    }
+
+    this.renderer.removeClass(this.elementRef.nativeElement, 'app-loading-button');
+    this.renderer.removeAttribute(this.elementRef.nativeElement, 'aria-busy');
+
+    if (this.restoreDisabled) {
+      this.renderer.setProperty(this.elementRef.nativeElement, 'disabled', false);
+    }
+  }
+}

--- a/src/app/shared/loading/loading.service.ts
+++ b/src/app/shared/loading/loading.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LoadingService {
+  private pendingCount = 0;
+  private readonly pendingSubject = new BehaviorSubject<number>(0);
+
+  readonly pending$ = this.pendingSubject.asObservable();
+
+  increment(): void {
+    this.pendingCount += 1;
+    this.pendingSubject.next(this.pendingCount);
+  }
+
+  decrement(): void {
+    this.pendingCount = Math.max(0, this.pendingCount - 1);
+    this.pendingSubject.next(this.pendingCount);
+  }
+
+  hasPending(): boolean {
+    return this.pendingCount > 0;
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -10,6 +10,7 @@ import {PaginadorComponent} from './paginador/paginador.component';
 import { SharedPaginatorComponent } from '../shared/pagination/shared-paginator/shared-paginator.component';
 import { LoadingComponent } from './loading/loading.component';
 import { PaginationService } from './pagination/pagination.service';
+import { LoadingButtonDirective } from './loading/loading-button.directive';
 
 
 @NgModule({
@@ -21,6 +22,7 @@ import { PaginationService } from './pagination/pagination.service';
         LoadingComponent,
         AutoExpandDirective,
         SharedPaginatorComponent,
+        LoadingButtonDirective,
     ],
     exports: [
         FooterComponent,
@@ -30,6 +32,7 @@ import { PaginationService } from './pagination/pagination.service';
         LoadingComponent,
         AutoExpandDirective,
         SharedPaginatorComponent,
+        LoadingButtonDirective,
     ],
     imports: [
         CommonModule,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,6 +5,30 @@ body {
   background: #f4f6f9 !important;
 }
 
+.app-loading-button {
+  position: relative;
+  pointer-events: none;
+}
+
+.app-loading-button::after {
+  content: '';
+  display: inline-block;
+  width: 0.9rem;
+  height: 0.9rem;
+  margin-left: 0.5rem;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  vertical-align: -0.1rem;
+  animation: app-loading-spin 0.6s linear infinite;
+}
+
+@keyframes app-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .fast {
   -webkit-animation-duration: 0.3s;
   animation-duration: 0.3s;


### PR DESCRIPTION
### Motivation
- Prevent users from accidentally performing the same action twice by disabling buttons while HTTP requests are in-flight and show a compact loading indicator. 
- Replace full page reloads used after inventory/distribution actions with targeted data refreshes to keep app state and UX stable.

### Description
- Add a global `LoadingService` and `LoadingInterceptor` that track active HTTP requests and update a shared pending counter used by UI controls (`src/app/shared/loading/loading.service.ts`, `src/app/interceptors/loading.interceptor.ts`).
- Introduce `LoadingButtonDirective` that targets all `button` elements to disable them on click, apply a visual loading class, and restore state when pending requests complete, and export it from `SharedModule` (`src/app/shared/loading/loading-button.directive.ts`, `src/app/shared/shared.module.ts`).
- Register the `LoadingInterceptor` in `AppModule` providers and add global styles for `.app-loading-button` in `src/styles.scss` to show a spinner and block pointer events.
- Replace full `window.location.reload()` calls in inventory/distribution flows with focused refresh helpers and guards: `refrescarDatosPostSincronizacion()` in `BodegasComponent`, and `cargarItemsParaPV(...)`, `refrescarDespuesAsignacion()` and async handling/guarding (`guardandoAsignacion`) in `DistribucionPvComponent`, plus an improved bodegas filter for exact searches.

### Testing
- Attempted to run the dev server with `npm start -- --host 0.0.0.0 --port 4200`, the Angular build started but was interrupted before completing so the full app run was not validated.
- No automated unit or e2e tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69836711aa90832e8629216037fbfdbc)